### PR TITLE
Branch to replace missing statements, make check batch more stringent, move conditions to improve speed

### DIFF
--- a/R/Utility_Functions.R
+++ b/R/Utility_Functions.R
@@ -19,15 +19,15 @@
 #' @export
 make_asv_list <- function(seqmat, taxmat, meta){
 
-  if (!is.matrix(seqmat) & !is.numeric(seqmat)){
+  if (!is.matrix(seqmat) && !is.numeric(seqmat)){
     stop("seqmat must be a numeric matrix")
   }
 
-  if (!is.matrix(taxmat) & !is.character(taxmat)){
+  if (!is.matrix(taxmat) && !is.character(taxmat)){
     stop("taxmat must be a character matrix")
   }
 
-  if (!is.data.frame(meta) & !identical(rownames(seqmat), rownames(meta))){
+  if (!is.data.frame(meta) && !identical(rownames(seqmat), rownames(meta))){
     stop("meta must be a data.frame with identical rownames to seqmat")
   }
 
@@ -166,7 +166,7 @@ melt_asv_list <- function(asv_list, ratio=FALSE, rescale=FALSE, sam_var, time_va
 #'
 #' clustersum_total <- sum_by_cluster(asv_list = asv_list, abs_abund = abs_abund)
 #'
-sum_by_cluster <- function(asv_list, abs_abund){
+sum_by_cluster <- function(asv_list, abs_abund = NULL){
 
   #establish objects
   cluster <- SampleID <- Abundance <- NULL
@@ -187,7 +187,7 @@ sum_by_cluster <- function(asv_list, abs_abund){
   meta <- asv_list$meta
   meta$SampleID <- rownames(meta)
 
-  if (!missing(abs_abund)){
+  if (!is.null(abs_abund)){
 
   if (!is.numeric(abs_abund[,1])){
   stop("First column of abs_abund data.frame must be a numeric vector of total abundance values for each sample")
@@ -199,7 +199,7 @@ sum_by_cluster <- function(asv_list, abs_abund){
   seqmat <- seqmat * abs_abund_vect
   seqmat <- as.data.frame(seqmat)
 
-  } else if (missing(abs_abund)){
+  } else if (is.null(abs_abund)){
 
   seqmat <- as.data.frame(seqmat)
 
@@ -248,7 +248,7 @@ sum_by_cluster <- function(asv_list, abs_abund){
 #' asv_list_dirty <- remove_samples(asv_list = asv_list, variable = "Treatment",
 #' variable_level = "Dirty-A")
 #'
-remove_samples <- function(asv_list, variable, variable_level){
+remove_samples <- function(asv_list, variable = NULL, variable_level){
 
   if (!isClass(asv_list, Class = c("list", "ASVclustr"))){
     stop("asv_list must be of classes list and ASVclustr")
@@ -262,7 +262,7 @@ remove_samples <- function(asv_list, variable, variable_level){
   meta$SampleID <- rownames(meta)
 
   #remove samples within variable level from seqmat and meta
-  if (!missing(variable)){
+  if (!is.null(variable)){
 
     meta2 <- meta[,c("SampleID", variable)]
     seqmat <- left_join(seqmat, meta2, "SampleID")
@@ -274,7 +274,7 @@ remove_samples <- function(asv_list, variable, variable_level){
     meta <- meta[!meta[,variable]%in% variable_level,]
 
   #remove samples by name
-  } else if (missing(variable)){
+  } else if (is.null(variable)){
 
     seqmat_sub <- seqmat[!seqmat[,"SampleID"] %in% variable_level,]
     meta <- meta[!meta[,"SampleID"] %in% variable_level,]
@@ -324,7 +324,7 @@ remove_samples <- function(asv_list, variable, variable_level){
 #' variable_level = "Dirty-A")
 #'
 #'
-subset_ASVs <- function(asv_list, sam_var, sam_threshold, abund_threshold){
+subset_ASVs <- function(asv_list, sam_var, sam_threshold, abund_threshold = NULL){
 
   if (!isClass(asv_list, Class = c("list", "ASVclustr"))){
     stop("asv_list must be of classes list and ASVclustr")
@@ -351,7 +351,7 @@ subset_ASVs <- function(asv_list, sam_var, sam_threshold, abund_threshold){
   remove_cols <- colnames(meta)
   join <- join[,!names(join) %in% c(remove_cols, "sample","SampleID")]
 
-  if(missing(abund_threshold)){
+  if(is.null(abund_threshold)){
 
     #keep ASVs present in n samples
     above_zero_counts <- data.frame(NonZeroCounts=colSums(join!=0)[colSums(join!=0)!=0])
@@ -361,7 +361,7 @@ subset_ASVs <- function(asv_list, sam_var, sam_threshold, abund_threshold){
     keep_OTUs <- above_zero_counts$OTU
     seqmat <- seqmat[,names(seqmat) %in% keep_OTUs]
 
-  } else if (!missing(abund_threshold)){
+  } else if (!is.null(abund_threshold)){
 
     #remove ASVs below a certain abundance threshold within all samples
     above_thresh_counts <- as.data.frame(colSums(join >= abund_threshold))

--- a/R/internal_functions.R
+++ b/R/internal_functions.R
@@ -67,6 +67,7 @@ order_seqmat <- function(seqmat, meta, sam_var,time_var){
 check_batch <- function(meta, independent_var, batch){
 
   #subset meta to variables needed, split into list of data.frames by batch level
+  independent_fact <- as.factor(meta[,independent_var])
   meta <- meta[,c(independent_var,batch)]
   meta <- split(meta, f = as.factor(meta[,batch]))
 
@@ -84,8 +85,9 @@ check_batch <- function(meta, independent_var, batch){
   #iterate function across list elements
   lengths <- sapply(meta, level_lengths, independent_var)
 
+
   #create logical vector from resulting vector. If the length is 1 it means there is only
   #one independent variable level for its respective batch, which means the batch level is inseparable
-  ifelse(lengths == 1, TRUE, FALSE)
+  ifelse(lengths == length(levels(independent_fact)), TRUE, FALSE)
 
 }

--- a/man/asv_clustr.Rd
+++ b/man/asv_clustr.Rd
@@ -4,7 +4,7 @@
 \alias{asv_clustr}
 \title{Hierarchical clustering of ASVs.}
 \usage{
-asv_clustr(asv_list, agg_method = "ward.D2", td = "none", k)
+asv_clustr(asv_list, agg_method = "ward.D2", td = "none", k = NULL)
 }
 \arguments{
 \item{asv_list}{An asv_list.}
@@ -17,8 +17,8 @@ asv_clustr(asv_list, agg_method = "ward.D2", td = "none", k)
 "both" will use both the abundance data and time rate derivative data.
 "td_only" will use only the time rate derivative data.}
 
-\item{k}{Optional. An integer. The number of clusters you wish to group your ASVs into. If k is missing asv_clustr will return
-a dendrogram plot instead}
+\item{k}{Optional. An integer. The number of clusters you wish to group your ASVs into. If a k is not chosen asv_clustr will
+return a dendrogram plot instead}
 }
 \value{
 An asv_list object, or a dendrogram if no k is set

--- a/man/compare_pd.Rd
+++ b/man/compare_pd.Rd
@@ -9,7 +9,7 @@ compare_pd(
   sam_var,
   time_var,
   independent_var,
-  batch,
+  batch = NULL,
   by_asv = FALSE,
   rescale = FALSE
 )

--- a/man/remove_samples.Rd
+++ b/man/remove_samples.Rd
@@ -4,7 +4,7 @@
 \alias{remove_samples}
 \title{Remove samples}
 \usage{
-remove_samples(asv_list, variable, variable_level)
+remove_samples(asv_list, variable = NULL, variable_level)
 }
 \arguments{
 \item{asv_list}{An asv_list object.}

--- a/man/subset_ASVs.Rd
+++ b/man/subset_ASVs.Rd
@@ -4,7 +4,7 @@
 \alias{subset_ASVs}
 \title{Subset ASVs by read count and presence.}
 \usage{
-subset_ASVs(asv_list, sam_var, sam_threshold, abund_threshold)
+subset_ASVs(asv_list, sam_var, sam_threshold, abund_threshold = NULL)
 }
 \arguments{
 \item{asv_list}{An asv_list object.}

--- a/man/sum_by_cluster.Rd
+++ b/man/sum_by_cluster.Rd
@@ -4,7 +4,7 @@
 \alias{sum_by_cluster}
 \title{Sum by cluster}
 \usage{
-sum_by_cluster(asv_list, abs_abund)
+sum_by_cluster(asv_list, abs_abund = NULL)
 }
 \arguments{
 \item{asv_list}{An asv list with an h_clust element.}


### PR DESCRIPTION
This branch improved check batch to prevent users from performing batch stratification in cases where a batch level would be perfect or partially confounding (i.e. missing from one or more test variable levels). While this woudn't cause an algebra error, it is still bad practice to attempt batch stratification on unbalanced batches.

Additionally, missing() was replaced by is.null() in every function where it was used for flow control, and appropriate arguments were set to NULL as default. This was done to make what arguments are optional more clear for an end user.

Finally, stop conditions were moved to the top of functions where possible, so that if an error would be thrown anyway it would happen immediately without wasting computation time.